### PR TITLE
EventFilter: Events for past months now load once in view.

### DIFF
--- a/App.js
+++ b/App.js
@@ -8,7 +8,7 @@ import Database from "./Database";
 import Styles from "./styles";
 import {createStackNavigator, createAppContainer, createSwitchNavigator} from "react-navigation";
 import {CalendarList} from "react-native-calendars";
-import {AppContainer, toDateTime, toDateString, randomColor, Dropdown, MoreButton} from "./util";
+import {AppContainer, toDateTime, toDateString, toMonthString, toLocalTime, randomColor, Dropdown, MoreButton} from "./util";
 import LoginView from "./views/LoginView";
 import {withMappedNavigationProps} from "react-navigation-props-mapper";
 
@@ -21,7 +21,8 @@ console.ignoredYellowBox = ['Setting a timer'];
 let loadedData = {
     clients: null,
     events: null,
-    venues: null
+    venues: null,
+    viewedMonths: null
 };
 
 let db = null;
@@ -31,10 +32,12 @@ class LoadingScreen extends React.Component {
     componentWillMount() {
         db = new Database();
 
-        Promise.all([db.getClients(), db.getMonthEvents(), db.getVenues()]).then(values => {
+        Promise.all([db.getClients(), db.getCurrentMonthAndUpcomingEvents(), db.getVenues()]).then(values => {
             loadedData.clients = values[0];
             loadedData.events = values[1];
             loadedData.venues = values[2];
+
+            loadedData.viewedMonths = [toMonthString(toLocalTime(new Date()))];
 
             this.props.navigation.navigate("App");
         }).catch(err => console.log(err));
@@ -113,12 +116,16 @@ class MonthView extends React.Component {
                     hideArrows = {Platform.OS !== "android"}
                     markingType = "multi-dot"
                     markedDates = {this._generateMarkedDates()}
-                    onVisibleMonthsChange = {(month) => {
-                        let monthString = month[0].dateString;
-                        Promise.all([db.getMonthEvents(monthString)]).then(values => {
-                            loadedData.events = values[0];
-                            this.forceUpdate();
-                        }).catch(err => console.log(err));
+                    onVisibleMonthsChange = {(date) => {
+                        let fullDate = date[0].dateString;
+                        let monthString = fullDate.substring(0, 7);
+                        if(!(loadedData.viewedMonths.includes(monthString)) && !(monthString > loadedData.viewedMonths[0])) {
+                            loadedData.viewedMonths.push(monthString);
+                            Promise.all([db.getMonthEvents(fullDate)]).then(values => {
+                                loadedData.events = loadedData.events.concat(values[0]);
+                                this.forceUpdate();
+                            }).catch(err => console.log(err));
+                        }
                     }}
                     onDayPress = {day => {
                         this.props.navigation.navigate("Day", {
@@ -129,18 +136,6 @@ class MonthView extends React.Component {
                         });
                     }}
                 />
-                <View style={Styles.buttonContainer}>
-                    {/* Load Archived Events Button */}
-                    <Button
-                        title = "Load Archived Events"
-                        onPress = {() => {
-                            Promise.all([db.getEvents()]).then(values => {
-                                loadedData.events = values[0];
-                                this.forceUpdate()
-                            }).catch(err => console.log(err));
-                        }}
-                    />
-                </View>
             </AppContainer>
         );
     }

--- a/Database.js
+++ b/Database.js
@@ -55,19 +55,20 @@ export default class Database {
         });
     }
 
-    // Load an archived day of past events.
-    getArchivedDayEvents(options) {
+    // Load all events for the current month and onwards.
+    // Assumption: Limited, since events should not be scheduled more than a few months in advance.
+    getCurrentMonthAndUpcomingEvents(options) {
         if (!options) {
             options = Date.now();
         }
 
         let archiveDate = new Date(options);
 
-        let archiveDay = toDateString(archiveDate);
+        let currentMonth = toMonthString(archiveDate);
 
         return new Promise((res, rej) => {
-            Firebase.database().ref('database/events').orderByChild('date').equalTo(archiveDay).once("value").then(data => {
-                let _events = data.val()
+            Firebase.database().ref('database/events').orderByChild('month').startAt(currentMonth).once("value").then(data => {
+                let _events = data.val();
                 let foundEvents = [];
                 for (let eventID in _events) {
                     if (_events.hasOwnProperty(eventID)) {
@@ -92,7 +93,7 @@ export default class Database {
 
         return new Promise((res, rej) => {
             Firebase.database().ref('database/events').orderByChild('month').equalTo(archiveMonth).once("value").then(data => {
-                let _events = data.val()
+                let _events = data.val();
                 let foundEvents = [];
                 for (let eventID in _events) {
                     if (_events.hasOwnProperty(eventID)) {
@@ -105,57 +106,83 @@ export default class Database {
         })
     }
 
-    // Load information for upcoming events and past events to the specified date.
-    getPastAndUpcomingEvents(options) {
-        if (!options) {
-            options = Date.now();
-        }
-
-        let cutoffTime = options;
-        let cutoffDate = new Date(cutoffTime);
-
-        let cutoffString = toDateString(cutoffDate);
-
-        return new Promise((res, rej) => {
-            Firebase.database().ref('database/events').orderByChild('date').startAt(cutoffString).once("value").then(data => {
-                let _events = data.val()
-                let foundEvents = [];
-                for (let eventID in _events) {
-                    if (_events.hasOwnProperty(eventID)) {
-                        let eventObj = new Event(_events[eventID], eventID);
-                        foundEvents.push(eventObj);
-                    }
-                }
-                res(foundEvents);
-            }).catch(err => rej(err));
-        })
-    }
-    // Load information for recent and upcoming events (The previous week and all future events).
-    // Assumption: Limited, since events should not be scheduled more than a few months in advance.
-    getRecentAndUpcomingEvents(options) {
-        if (!options) {
-            options = {}
-        }
-
-        let cutoffTime = Date.now() - (7 * (24 * 60 * 60 * 1000));
-        let cutoffDate = new Date(cutoffTime);
-
-        let cutoffString = toDateString(cutoffDate);
-
-        return new Promise((res, rej) => {
-            Firebase.database().ref('database/events').orderByChild('date').startAt(cutoffString).once("value").then(data => {
-                let _events = data.val()
-                let foundEvents = [];
-                for (let eventID in _events) {
-                    if (_events.hasOwnProperty(eventID)) {
-                        let eventObj = new Event(_events[eventID], eventID);
-                        foundEvents.push(eventObj);
-                    }
-                }
-                res(foundEvents);
-            }).catch(err => rej(err));
-        })
-    }
+    // // Load an archived day of past events.
+    // getArchivedDayEvents(options) {
+    //     if (!options) {
+    //         options = Date.now();
+    //     }
+    //
+    //     let archiveDate = new Date(options);
+    //
+    //     let archiveDay = toDateString(archiveDate);
+    //
+    //     return new Promise((res, rej) => {
+    //         Firebase.database().ref('database/events').orderByChild('date').equalTo(archiveDay).once("value").then(data => {
+    //             let _events = data.val();
+    //             let foundEvents = [];
+    //             for (let eventID in _events) {
+    //                 if (_events.hasOwnProperty(eventID)) {
+    //                     let eventObj = new Event(_events[eventID], eventID);
+    //                     foundEvents.push(eventObj);
+    //                 }
+    //             }
+    //             res(foundEvents);
+    //         }).catch(err => rej(err));
+    //     })
+    // }
+    //
+    // // Load information for upcoming events and past events to the specified date.
+    // getPastAndUpcomingEvents(options) {
+    //     if (!options) {
+    //         options = Date.now();
+    //     }
+    //
+    //     let cutoffTime = options;
+    //     let cutoffDate = new Date(cutoffTime);
+    //
+    //     let cutoffString = toDateString(cutoffDate);
+    //
+    //     return new Promise((res, rej) => {
+    //         Firebase.database().ref('database/events').orderByChild('date').startAt(cutoffString).once("value").then(data => {
+    //             let _events = data.val();
+    //             let foundEvents = [];
+    //             for (let eventID in _events) {
+    //                 if (_events.hasOwnProperty(eventID)) {
+    //                     let eventObj = new Event(_events[eventID], eventID);
+    //                     foundEvents.push(eventObj);
+    //                 }
+    //             }
+    //             res(foundEvents);
+    //         }).catch(err => rej(err));
+    //     })
+    // }
+    //
+    // // Load information for recent and upcoming events (The previous week and all future events).
+    // // Assumption: Limited, since events should not be scheduled more than a few months in advance.
+    // getRecentAndUpcomingEvents(options) {
+    //     if (!options) {
+    //         options = {}
+    //     }
+    //
+    //     let cutoffTime = Date.now() - (7 * (24 * 60 * 60 * 1000));
+    //     let cutoffDate = new Date(cutoffTime);
+    //
+    //     let cutoffString = toDateString(cutoffDate);
+    //
+    //     return new Promise((res, rej) => {
+    //         Firebase.database().ref('database/events').orderByChild('date').startAt(cutoffString).once("value").then(data => {
+    //             let _events = data.val();
+    //             let foundEvents = [];
+    //             for (let eventID in _events) {
+    //                 if (_events.hasOwnProperty(eventID)) {
+    //                     let eventObj = new Event(_events[eventID], eventID);
+    //                     foundEvents.push(eventObj);
+    //                 }
+    //             }
+    //             res(foundEvents);
+    //         }).catch(err => rej(err));
+    //     })
+    // }
 
     getVenues() {
             return new Promise((res, rej) => {


### PR DESCRIPTION
Events will now load into the application when a month first comes into view on the calendar.
I've also changed the default query on startup to load all events for the current month and onward.