### PR TITLE
Fixed a fatal error with concatenating undefined events (empty array)…

### DIFF
--- a/views/EventView.js
+++ b/views/EventView.js
@@ -156,17 +156,15 @@ export default class EventView extends React.Component {
                                 let selected = buttons.find(b => b.checked);
 
                                 if (selected.value === "c") {
-                                    let splits = defaultTimes[0].split("-");
+                                    this.setState({customTime: true});
+                                } else {
+                                    let splits = selected.label.split("-");
 
-                                    let newState = {
+                                    this.setState({
                                         startTime: toMilitaryTime(splits[0].trim()),
                                         endTime: toMilitaryTime(splits[1].trim()),
-                                        customTime: true
-                                    };
-
-                                    this.setState(newState);
-                                } else {
-                                    this.setState({customTime: false});
+                                        customTime: false
+                                    });
                                 }
                             }}
                         />


### PR DESCRIPTION
… to loadedData.events.

Found a fatal error last night that occurred when I tried to load January 2019 in the calendar.
Figured out that it was an issue with concatenating empty arrays to loadedData.events when loading data for previous empty months.